### PR TITLE
Stats endpoint

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -6,7 +6,8 @@
     "timeout": "3s",
     "extra_config": {
       "github_com/devopsfaith/krakend-metrics": {
-        "collection_time": "30s"
+        "collection_time": "30s",
+        "listen_address": "127.0.0.1:8090"
       }
     },
     "endpoints": [

--- a/examples/main.go
+++ b/examples/main.go
@@ -61,7 +61,7 @@ func main() {
 		routerCfg.HandlerFactory = metric.NewHTTPHandlerFactory(defaultHandlerFactory)
 		routerFactory := mux.NewFactory(routerCfg)
 		// register the stats endpoint
-		routerCfg.Engine.Handle("/__stats/", metric.NewExpHandler())
+		routerCfg.Engine.Handle("/__stats", metric.NewExpHandler())
 
 		routerFactory.NewWithContext(ctx).Run(serviceConfig)
 
@@ -84,7 +84,7 @@ func main() {
 			Logger:      logger,
 		})
 		// register the stats endpoint
-		engine.GET("/__stats/", metric.NewExpHandler())
+		engine.GET("/__stats", metric.NewExpHandler())
 
 		routerFactory.NewWithContext(ctx).Run(serviceConfig)
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -60,8 +60,6 @@ func main() {
 		// declare the instrumented router handler
 		routerCfg.HandlerFactory = metric.NewHTTPHandlerFactory(defaultHandlerFactory)
 		routerFactory := mux.NewFactory(routerCfg)
-		// register the stats endpoint
-		routerCfg.Engine.Handle("/__stats", metric.NewExpHandler())
 
 		routerFactory.NewWithContext(ctx).Run(serviceConfig)
 
@@ -83,10 +81,7 @@ func main() {
 			Middlewares: []gin.HandlerFunc{},
 			Logger:      logger,
 		})
-		// register the stats endpoint
-		engine.GET("/__stats", metric.NewExpHandler())
 
 		routerFactory.NewWithContext(ctx).Run(serviceConfig)
-
 	}
 }

--- a/gin/metrics.go
+++ b/gin/metrics.go
@@ -60,7 +60,7 @@ func (m *Metrics) NewEngine() *gin.Engine {
 	engine.RedirectFixedPath = true
 	engine.HandleMethodNotAllowed = true
 
-	engine.GET("/__stats/", m.NewExpHandler())
+	engine.GET("/__stats", m.NewExpHandler())
 	return engine
 }
 

--- a/gin/metrics_test.go
+++ b/gin/metrics_test.go
@@ -3,6 +3,8 @@ package gin
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -56,7 +58,7 @@ func TestNew(t *testing.T) {
 		CacheTTL: time.Second,
 	}
 	engine.GET("/test/:var", hf(cfg, p))
-	engine.GET("/__stats", metric.NewExpHandler())
+	statsEngine := metric.NewEngine()
 
 	for i := 0; i < 100; i++ {
 		w := httptest.NewRecorder()
@@ -96,10 +98,36 @@ func TestNew(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/__stats", nil)
-	engine.ServeHTTP(w, req)
+	req, _ := http.NewRequest("GET", "/__stats/", nil)
+	statsEngine.ServeHTTP(w, req)
 
 	if w.Result().StatusCode != 200 {
 		t.Errorf("unexpected status code: %d\n", w.Result().StatusCode)
+	}
+}
+
+func TestStatsEndpoint(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	buf := bytes.NewBuffer(make([]byte, 1024))
+	l, _ := logging.NewLogger("DEBUG", buf, "")
+	cfg := map[string]interface{}{metrics.Namespace: map[string]interface{}{"collection_time": "100ms", "stats_port": 8999}}
+	_ = New(ctx, cfg, l)
+	resp, err := http.Get("http://localhost:8999/__stats/")
+	if err != nil {
+		t.Errorf("Problem with the stats endpoint: %s\n", err.Error())
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("Cannot read body: %s\n", err.Error())
+	}
+	var stats map[string]interface{}
+	err = json.Unmarshal(body, &stats)
+	if err != nil {
+		t.Errorf("Proble unmarshaling stats endpoint response: %s\n", err.Error())
+	}
+	if _, ok := stats["cmdline"]; !ok {
+		t.Error("Key cmdline should exists in the response.\n")
 	}
 }

--- a/gin/metrics_test.go
+++ b/gin/metrics_test.go
@@ -111,7 +111,7 @@ func TestStatsEndpoint(t *testing.T) {
 	defer cancel()
 	buf := bytes.NewBuffer(make([]byte, 1024))
 	l, _ := logging.NewLogger("DEBUG", buf, "")
-	cfg := map[string]interface{}{metrics.Namespace: map[string]interface{}{"collection_time": "100ms", "stats_port": 8999}}
+	cfg := map[string]interface{}{metrics.Namespace: map[string]interface{}{"collection_time": "100ms", "listen_address": ":8999"}}
 	_ = New(ctx, cfg, l)
 	resp, err := http.Get("http://localhost:8999/__stats/")
 	if err != nil {

--- a/gin/metrics_test.go
+++ b/gin/metrics_test.go
@@ -98,7 +98,7 @@ func TestNew(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/__stats/", nil)
+	req, _ := http.NewRequest("GET", "/__stats", nil)
 	statsEngine.ServeHTTP(w, req)
 
 	if w.Result().StatusCode != 200 {
@@ -113,7 +113,7 @@ func TestStatsEndpoint(t *testing.T) {
 	l, _ := logging.NewLogger("DEBUG", buf, "")
 	cfg := map[string]interface{}{metrics.Namespace: map[string]interface{}{"collection_time": "100ms", "listen_address": ":8999"}}
 	_ = New(ctx, cfg, l)
-	resp, err := http.Get("http://localhost:8999/__stats/")
+	resp, err := http.Get("http://localhost:8999/__stats")
 	if err != nil {
 		t.Errorf("Problem with the stats endpoint: %s\n", err.Error())
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -1,4 +1,4 @@
-// Package metrics defines a set of basic building blocks for instrumenting KakenD gateways
+// Package metrics defines a set of basic building blocks for instrumenting KrakenD gateways
 //
 // Check the "github.com/devopsfaith/krakend-metrics/gin" and "github.com/devopsfaith/krakend-metrics/mux"
 // packages for complete implementations
@@ -15,6 +15,8 @@ import (
 	"github.com/rcrowley/go-metrics"
 )
 
+var defaultStatsPort int = 8090
+
 // New creates a new metrics producer
 func New(ctx context.Context, e config.ExtraConfig, l logging.Logger) *Metrics {
 	registry := metrics.NewPrefixedRegistry("krakend.")
@@ -22,6 +24,15 @@ func New(ctx context.Context, e config.ExtraConfig, l logging.Logger) *Metrics {
 	var cfg *Config
 	if tmp, ok := ConfigGetter(e).(*Config); ok {
 		cfg = tmp
+	}
+
+	if cfg == nil {
+		registry = NewDummyRegistry()
+		return &Metrics{
+			Registry: &registry,
+			Router:   &RouterMetrics{},
+			Proxy:    &ProxyMetrics{},
+		}
 	}
 
 	m := Metrics{
@@ -32,9 +43,7 @@ func New(ctx context.Context, e config.ExtraConfig, l logging.Logger) *Metrics {
 		latestSnapshot: NewStats(),
 	}
 
-	if m.Config != nil {
-		m.processMetrics(ctx, m.Config.CollectionTime, logger{l})
-	}
+	m.processMetrics(ctx, m.Config.CollectionTime, logger{l})
 
 	return &m
 }
@@ -44,10 +53,12 @@ const Namespace = "github_com/devopsfaith/krakend-metrics"
 
 // Config holds if a component is active or not
 type Config struct {
-	ProxyDisabled   bool `json:"proxy_disabled,omitempty"`
-	RouterDisabled  bool `json:"router_disabled,omitempty"`
-	BackendDisabled bool `json:"backend_disabled,omitempty"`
-	CollectionTime  time.Duration
+	ProxyDisabled    bool
+	RouterDisabled   bool
+	BackendDisabled  bool
+	CollectionTime   time.Duration
+	StatsPort        int
+	EndpointDisabled bool
 }
 
 // ConfigGetter implements the config.ConfigGetter interface. It parses the extra config for the
@@ -70,9 +81,16 @@ func ConfigGetter(e config.ExtraConfig) interface{} {
 			userCfg.CollectionTime = d
 		}
 	}
+	userCfg.StatsPort = defaultStatsPort
+	if statsPort, ok := tmp["stats_port"]; ok {
+		if p, ok := statsPort.(int); ok {
+			userCfg.StatsPort = p
+		}
+	}
 	userCfg.ProxyDisabled = getBool(tmp, "proxy_disabled")
 	userCfg.RouterDisabled = getBool(tmp, "router_disabled")
 	userCfg.BackendDisabled = getBool(tmp, "backend_disabled")
+	userCfg.EndpointDisabled = getBool(tmp, "endpoint_disabled")
 
 	return userCfg
 }
@@ -164,4 +182,21 @@ type logger struct {
 
 func (l logger) Printf(format string, v ...interface{}) {
 	l.logger.Debug(strings.TrimRight(fmt.Sprintf(format, v...), "\n"))
+}
+
+type DummyRegistry struct{}
+
+func (r DummyRegistry) Each(_ func(string, interface{})) {}
+func (r DummyRegistry) Get(_ string) interface{}         { return nil }
+func (r DummyRegistry) GetAll() map[string]map[string]interface{} {
+	return map[string]map[string]interface{}{}
+}
+func (r DummyRegistry) GetOrRegister(_ string, i interface{}) interface{} { return i }
+func (r DummyRegistry) Register(_ string, _ interface{}) error            { return nil }
+func (r DummyRegistry) RunHealthchecks()                                  {}
+func (r DummyRegistry) Unregister(_ string)                               {}
+func (r DummyRegistry) UnregisterAll()                                    {}
+
+func NewDummyRegistry() metrics.Registry {
+	return DummyRegistry{}
 }

--- a/metrics.go
+++ b/metrics.go
@@ -15,7 +15,8 @@ import (
 	"github.com/rcrowley/go-metrics"
 )
 
-var defaultStatsPort int = 8090
+// defaultListenAddrt is the default listen address:port for the stats endpoint service
+var defaultListenAddr = ":8090"
 
 // New creates a new metrics producer
 func New(ctx context.Context, e config.ExtraConfig, l logging.Logger) *Metrics {
@@ -57,7 +58,7 @@ type Config struct {
 	RouterDisabled   bool
 	BackendDisabled  bool
 	CollectionTime   time.Duration
-	StatsPort        int
+	ListenAddr       string
 	EndpointDisabled bool
 }
 
@@ -81,10 +82,10 @@ func ConfigGetter(e config.ExtraConfig) interface{} {
 			userCfg.CollectionTime = d
 		}
 	}
-	userCfg.StatsPort = defaultStatsPort
-	if statsPort, ok := tmp["stats_port"]; ok {
-		if p, ok := statsPort.(int); ok {
-			userCfg.StatsPort = p
+	userCfg.ListenAddr = defaultListenAddr
+	if listenAddr, ok := tmp["listen_address"]; ok {
+		if a, ok := listenAddr.(string); ok {
+			userCfg.ListenAddr = a
 		}
 	}
 	userCfg.ProxyDisabled = getBool(tmp, "proxy_disabled")
@@ -184,6 +185,7 @@ func (l logger) Printf(format string, v ...interface{}) {
 	l.logger.Debug(strings.TrimRight(fmt.Sprintf(format, v...), "\n"))
 }
 
+// DummyRegistry implements the rcrowley/go-metrics.Registry interface
 type DummyRegistry struct{}
 
 func (r DummyRegistry) Each(_ func(string, interface{})) {}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -18,7 +18,7 @@ func TestConfigGetter(t *testing.T) {
 			"proxy_disabled":  true,
 			"router_disabled": true,
 			"collection_time": "100ms",
-			"stats_port":      8888,
+			"listen_address":  "192.168.1.1:8888",
 		},
 	}
 	testCfg := ConfigGetter(sampleCfg).(*Config)
@@ -34,8 +34,8 @@ func TestConfigGetter(t *testing.T) {
 	if testCfg.CollectionTime != 100*time.Millisecond {
 		t.Errorf("Unexpected collection time: %v", testCfg.CollectionTime)
 	}
-	if testCfg.StatsPort != 8888 {
-		t.Errorf("Unexpected port: %d", testCfg.StatsPort)
+	if testCfg.ListenAddr != "192.168.1.1:8888" {
+		t.Errorf("Unexpected addr: %s", testCfg.ListenAddr)
 	}
 }
 

--- a/mux/metrics.go
+++ b/mux/metrics.go
@@ -4,7 +4,6 @@ package mux
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"
+	krakendgin "github.com/devopsfaith/krakend/router/gin"
 	"github.com/devopsfaith/krakend/router/mux"
 	"github.com/gin-gonic/gin"
 	"github.com/rcrowley/go-metrics"
@@ -24,7 +24,7 @@ import (
 func New(ctx context.Context, e config.ExtraConfig, l logging.Logger) *Metrics {
 	metricsCollector := Metrics{krakendmetrics.New(ctx, e, l)}
 	if metricsCollector.Config != nil && !metricsCollector.Config.EndpointDisabled {
-		metricsCollector.RunEndpoint(metricsCollector.NewEngine(), l)
+		metricsCollector.RunEndpoint(ctx, metricsCollector.NewEngine(), l)
 	}
 	return &metricsCollector
 }
@@ -35,14 +35,14 @@ type Metrics struct {
 }
 
 // RunEndpoint runs the *gin.Engine (that should have the stats endpoint) with the logger
-func (m *Metrics) RunEndpoint(e *gin.Engine, l logging.Logger) {
-	s := &http.Server{
-		Addr:    fmt.Sprintf(":%d", m.Config.StatsPort),
-		Handler: e,
-	}
-	go func() {
-		l.Critical(s.ListenAndServe())
-	}()
+func (m *Metrics) RunEndpoint(ctx context.Context, e *gin.Engine, l logging.Logger) {
+	statsFactory := krakendgin.NewFactory(krakendgin.Config{
+		Engine: e,
+		Logger: l,
+	})
+	go statsFactory.NewWithContext(ctx).Run(config.ServiceConfig{
+		Port: m.Config.StatsPort,
+	})
 }
 
 // NewEngine returns a *gin.Engine with some defaults and the stats endpoint (no logger)

--- a/mux/metrics.go
+++ b/mux/metrics.go
@@ -58,16 +58,6 @@ func (m *Metrics) NewEngine() *gin.Engine {
 	return engine
 }
 
-// func (m *Metrics) RunEndpoint() {
-// 	engine := gin.Default()
-// 	engine.RedirectTrailingSlash = true
-// 	engine.RedirectFixedPath = true
-// 	engine.HandleMethodNotAllowed = true
-//
-// 	engine.GET("/__stats/", gin.WrapH(m.NewExpHandler()))
-// 	go engine.Run(fmt.Sprintf(":%d", m.Config.StatsPort))
-// }
-
 // NewExpHandler creates an http.Handler ready to expose all the collected metrics as a JSON
 func (m *Metrics) NewExpHandler() http.Handler {
 	return NewExpHandler(m.Registry)

--- a/mux/metrics_test.go
+++ b/mux/metrics_test.go
@@ -202,7 +202,7 @@ func TestStatsEndpoint(t *testing.T) {
 	l, _ := logging.NewLogger("DEBUG", buf, "")
 	cfg := map[string]interface{}{krakendmetrics.Namespace: map[string]interface{}{"collection_time": "100ms", "listen_address": ":8999"}}
 	_ = New(ctx, cfg, l)
-	resp, err := http.Get("http://localhost:8999/__stats/")
+	resp, err := http.Get("http://localhost:8999/__stats")
 	if err != nil {
 		t.Errorf("Problem with the stats endpoint: %s\n", err.Error())
 	}

--- a/mux/metrics_test.go
+++ b/mux/metrics_test.go
@@ -200,7 +200,7 @@ func TestStatsEndpoint(t *testing.T) {
 	defer cancel()
 	buf := bytes.NewBuffer(make([]byte, 1024))
 	l, _ := logging.NewLogger("DEBUG", buf, "")
-	cfg := map[string]interface{}{krakendmetrics.Namespace: map[string]interface{}{"collection_time": "100ms", "stats_port": 8999}}
+	cfg := map[string]interface{}{krakendmetrics.Namespace: map[string]interface{}{"collection_time": "100ms", "listen_address": ":8999"}}
 	_ = New(ctx, cfg, l)
 	resp, err := http.Get("http://localhost:8999/__stats/")
 	if err != nil {


### PR DESCRIPTION
Start the stats endpoint on it's own server. Supports disabling it by configuration.
You are now able to disable the middleware.