### PR TITLE
remove the metrics log

### DIFF
--- a/gin/metrics_example_test.go
+++ b/gin/metrics_example_test.go
@@ -14,9 +14,9 @@ import (
 	metrics "github.com/devopsfaith/krakend-metrics"
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/encoding"
-	"github.com/devopsfaith/krakend/transport/http/client"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"
+	"github.com/devopsfaith/krakend/transport/http/client"
 	"github.com/gin-gonic/gin"
 )
 

--- a/metrics.go
+++ b/metrics.go
@@ -154,8 +154,6 @@ func (m *Metrics) processMetrics(ctx context.Context, d time.Duration, l metrics
 	metrics.RegisterDebugGCStats(r)
 	metrics.RegisterRuntimeMemStats(r)
 
-	go metrics.Log(r, d, l)
-
 	go func() {
 		ticker := time.NewTicker(d)
 		for {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -119,8 +119,8 @@ func TestBadConfiguration(t *testing.T) {
 func TestMetrics(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	buf := bytes.NewBuffer(make([]byte, 1024))
-	l, _ := logging.NewLogger("DEBUG", buf, "")
+
+	l, _ := logging.NewLogger("DEBUG", new(bytes.Buffer), "")
 	cfg := map[string]interface{}{Namespace: map[string]interface{}{"collection_time": "100ms"}}
 	m := New(ctx, cfg, l)
 	stats1 := m.Snapshot()
@@ -130,12 +130,6 @@ func TestMetrics(t *testing.T) {
 	if stats1.Time > stats2.Time {
 		t.Error("the later stat must have a higher timestamp")
 		return
-	}
-	// sleep some time so the producer is able to collect some logs
-	time.Sleep(200 * time.Millisecond)
-	lines := len(strings.Split(buf.String(), "\n"))
-	if lines < 50 {
-		t.Error("unexpected log size. got:", lines)
 	}
 }
 

--- a/mux/metrics_example_test.go
+++ b/mux/metrics_example_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/encoding"
 	"github.com/devopsfaith/krakend/logging"
-	"github.com/devopsfaith/krakend/transport/http/client"
 	"github.com/devopsfaith/krakend/proxy"
+	"github.com/devopsfaith/krakend/transport/http/client"
 )
 
 var defaultCfg = map[string]interface{}{metrics.Namespace: map[string]interface{}{"collection_time": "100ms"}}


### PR DESCRIPTION
Since there are other ways to export the metrics, the logger makes no sense anymore